### PR TITLE
run github action against PR commit

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -7,7 +7,11 @@ jobs:
   ci-e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: install go
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
This PR uses explicit GitHub Actions configuration so that the ci-e2e workflow runs tests against the PR-originating commit.