### PR TITLE
Fix optional cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ cl2-metadata.json
 junit.xml
 generatedConfig_pod-churn.yaml
 generatedConfig_deployment-churn.yaml
+generatedConfig_naked-pod-churn.yaml

--- a/test/workloads/deployment-churn/churn-module.yaml
+++ b/test/workloads/deployment-churn/churn-module.yaml
@@ -59,11 +59,8 @@ steps:
     Method: WaitForRunningPods
     Params:
       desiredPodCount: {{$.totalPods}} 
-      labelSelector: test-pod = deployment-churn  # match all our pods, regardless of the round, since we sometimes only do partial churn (i.e. leave ones from older rounds)
+      labelSelector: test-round in (r1, r{{$.roundNumber}})  # since we may carry some over from round 1
       timeout: {{$.timeout}}
-      # TODO: why did the label selector seem to pick up pods from other CL2 namespaces? Is that normal? Can it be avoided?
-      # For now, we are avoiding it by configuring teh test to delete stale test namespaces when it starts, so there won't be 
-      # any such unwanted pods.
 
 - name: end wait timer
   measurements:

--- a/test/workloads/deployment-churn/config.yaml
+++ b/test/workloads/deployment-churn/config.yaml
@@ -12,8 +12,12 @@ name: deployment-churn
 {{$TARGET_POD_CHURN := DefaultParam .CL2_TARGET_POD_CHURN 10}}  # i.e. target pod churn, in mutations/sec, for cluster as a whole. (create+update+delete operations per second)
 {{$POD_START_TIMEOUT_MINS := DefaultParam .CL2_POD_START_TIMEOUT_MINS 5}}  # how long to wait, at end of a phase, for its pods to start up
 {{$CHURN_FRACTION := DefaultParam .CL2_CHURN_FRACTION 0.3}}
-{{$CLEANUP := DefaultParam .CL2_CLEANUP 1}}  # See comments below on optional cleanup. Should we cleanup our own pods?  1 = yes. All other values = let them be cleaned up in the auto namespace deletion
-
+{{$CLEANUP := DefaultParam .CL2_CLEANUP 1}}  
+# Note on CLEANUP of pods and deployments that we create.
+# By default we do clean them up explicitly, because by default letting them just get deleted with the namespace is slow.
+# However, if delete-collection-workers has been set to a highish value (e.g. 250) in the API server params, then 
+# there is no need for us to delete them explicitly. They'l be deleted quickly when this test deletes its namespace.
+# So, if you have set that parameter in your API server, then set the CL2_CLEANUP parameter to 0
 
 # computed params
 {{$desiredConcurrentPods := MultiplyInt .Nodes $ACTIVE_PODS_PER_NODE}}  #Total number of active pods for cluster
@@ -27,15 +31,6 @@ name: deployment-churn
 {{$deploymentsToKeep := SubtractInt $desiredConcurrentDeployments $deploymentsToRecreate}} # keep this many from round 1, running throughpout round 2
 {{$expectedSecondsInStartupPhase := DivideInt $desiredConcurrentDeployments $targetDeploymentCreationsPerSecond}}  # expected duration of round 1
 {{$expectedSecondsInChurnPhase := DivideInt $deploymentsToRecreate $targetDeploymentCreationsPerSecond}}  # expected duration of round 2
-
-# Configure optional cleanup
-# By default we do clean them up explicitly, because by default letting them just get deleted with the namespace is slow.
-# However, if delete-collection-workers has been set to a highish value (e.g. 250) in the API server params, then 
-# there is no need for us to delete them explicitly. They'l be deleted quickly when this test deletes its namespace.
-# So, if you have set that parameter in your API server, then set the CL2_CLEANUP parameter to 0
-{{$cleanupPhaseDesc := IfThenElse (eq $CLEANUP 1) "Cleanup" "No-op (skipped cleanup)"}}
-{{$cleanupPhaseRoundNumber := IfThenElse (eq $CLEANUP 1) 3 99}} # if we don't want cleanup, just move this round 99, so it will be a no-op when it tries to cleanup the non-existent round 98
-{{$cleanupPhaseExpectedConcurrentPods := IfThenElse (eq $CLEANUP 1) 0 $expectedConcurrentPods}}  # if we don't want cleanup, expected number is just the full complement of pods
 
 {{$podStartTimeout := print $POD_START_TIMEOUT_MINS "m"}}
 
@@ -96,16 +91,19 @@ steps:
       podsPerDeployment: {{$PODS_PER_DEPLOYMENT}}
       totalPods: {{$expectedConcurrentPods}}
       timeout: {{$podStartTimeout}}
+
+{{if ne $CLEANUP 0}}      
 - module:
     path: /churn-module.yaml
     params:
-      roundNumber: {{$cleanupPhaseRoundNumber}} # this is the optional cleanup round (we make it "optional" by setting its round number to something really high, so it has nothing to cleanup from the immediately previous round, beceause there is no such round)
-      desc: {{$cleanupPhaseDesc}}
+      roundNumber: 3
+      desc: Cleanup
       oldReplicasAfterDeletion: 0
       newReplicas: 0          
       podsPerDeployment: {{$PODS_PER_DEPLOYMENT}}
-      totalPods: {{$cleanupPhaseExpectedConcurrentPods}}            # will be zero iff cleanup has been requested
+      totalPods: 0
       timeout: {{$podStartTimeout}}
+{{end}}
 
 ### Gather measurements
 - name: Gather measurements

--- a/test/workloads/deployment-churn/deployment.yaml
+++ b/test/workloads/deployment-churn/deployment.yaml
@@ -15,7 +15,6 @@ spec:
       labels:
         app: {{.Name}}
         test-round: {{$.testRound}}
-        test-pod: deployment-churn
     spec:    
       containers:
       - name: load-test

--- a/test/workloads/naked-pod-churn/config.yaml
+++ b/test/workloads/naked-pod-churn/config.yaml
@@ -18,7 +18,12 @@ name: naked-pod-churn
 {{$ACTIVE_PODS_PER_NODE := DefaultParam .CL2_PODS_PER_NODE 60}}
 {{$TARGET_POD_CHURN := DefaultParam .CL2_TARGET_POD_CHURN 10}}  # i.e. target pod churn, in mutations/sec, for cluster as a whole. (create+update+delete operations per second)
 {{$POD_START_TIMEOUT_MINS := DefaultParam .CL2_POD_START_TIMEOUT_MINS 5}}  # how long to wait, at end of a phase, for its pods to start up
-
+{{$CLEANUP := DefaultParam .CL2_CLEANUP 1}}  
+# Note on CLEANUP of pods and deployments that we create.
+# By default we do clean them up explicitly, because by default letting them just get deleted with the namespace is slow.
+# However, if delete-collection-workers has been set to a highish value (e.g. 250) in the API server params, then 
+# there is no need for us to delete them explicitly. They'l be deleted quickly when this test deletes its namespace.
+# So, if you have set that parameter in your API server, then set the CL2_CLEANUP parameter to 0
 
 # computed params
 {{$desiredConcurrentPods := MultiplyInt .Nodes $ACTIVE_PODS_PER_NODE}}  #Total number of active pods for cluster
@@ -91,6 +96,8 @@ steps:
       roundNumber: 2  # this round does the real work
       desc: Do the churn test
       timeout: {{$podStartTimeout}}
+
+{{if ne $CLEANUP 0}}         
 - module:
     path: /churn-module.yaml
     params:
@@ -98,6 +105,7 @@ steps:
       roundNumber: 3
       desc: Cleanup remaining pods
       timeout: {{$podStartTimeout}}
+{{end}}
 
 ### Gather measurements
 - name: Gather measurements


### PR DESCRIPTION
By using the proper golang template conditional support

Seems to also fix the pervious weird bugs with the cleanup filters not finding the right pods