### PR TITLE
Spread work over multiple namespaces

### DIFF
--- a/test/workloads/README.md
+++ b/test/workloads/README.md
@@ -6,17 +6,29 @@ The tests get their target node count automatically via the `.Nodes` variable, w
 
 Other parameters, such as pod density, can be provided through environment variables or a ClusterLoader2 overrides file.
 
-To run a test manually in ClusterLoader2, use a command line something like this (note that the env vars shown here are specific to the POD churn test.
-Look at the CL2 vars used in each test to know which ones to set for other tests)
+To run a test manually in ClusterLoader2, use a command line something like this (note that the env vars shown here are specific to the deployment churn test)
 
-Bash:
+Bash. Mimimal set of parameters
 ```
-CL2_PODS_PER_NODE=12 CL2_TARGET_POD_CHURN=20 ~/go/src/github.com/kubernetes/perf-tests/clusterloader2/clusterloader2 --testconfig=./test/workloads/pod-churn/config.yaml --provider=aks --kubeconfig=$HOME/.kube/config --v=2 --enable-exec-service=false --delete-automanaged-namespaces
+CL2_PODS_PER_NODE=6 CL2_TARGET_POD_CHURN=50 CL2_PODS_PER_DEPLOYMENT=20 ~/go/src/github.com/kubernetes/perf-tests/clusterloader2/clusterloader2 --testconfig=./test/workloads/deployment-churn/config.yaml --provider=aks --kubeconfig=$HOME/.kube/config --v=2 --enable-exec-service=false
 ```
 
+# Running tests faster
 
-Or in PowerShell:
+To run tests faster, set up your api server to have its command line parameter `delete-collection-workers`
+set to a relatively high figure (e.g. 250 instead of its default value of 1).  Then set these two 
+parameters at the start of your commmand:
 
 ```
-$env:CLUSTERLOADERROOT="<pathToClusterLoader2Binary>"; $env:CL2_PODS_PER_NODE=12; $env:CL2_TARGET_POD_CHURN=200; ./clusterloader --testconfig<path>/pod-churn/config.yaml --provider=aks --kubeconfig=$env:USERPROFILE/.kube/config --v=2 --enable-exec-service=false --delete-stale-namespaces
+CL2_CLEANUP=0 CL2_CHURN_FRACTION=0.5
 ```
+
+The cleanup parameter supresses explicit deletion of the created objects, and lets deletion
+happen as part of the namespace deletion that happens automatically at the end of the test.
+For non-trivial load tests, that is performant only if `delete-collection-workers` has been set 
+as noted above.
+
+The churn fraction parameter says what fraction of the running pods should be replaced in the 
+"churn" phase of the test. By default, that fraction is 1.0, i.e. all of them.  But for tests 
+with lots of pods, you might want something that runs quicker than the default. So you can use 
+`0.5` or any other value between 0 and 1.

--- a/test/workloads/deployment-churn/README.md
+++ b/test/workloads/deployment-churn/README.md
@@ -1,3 +1,8 @@
 This test is about using deployments to create pods, rather than naked pods as we do 
-in the other pod-churn test.
+in the naked-pod-churn test.
+
+This test, the deployment-based one, superceeds the naked pod one because this one has more features 
+and gives a more realistic test scenario.
+
+For sample command line, see parent readme.md
 

--- a/test/workloads/deployment-churn/churn-module.yaml
+++ b/test/workloads/deployment-churn/churn-module.yaml
@@ -20,7 +20,7 @@ steps:
   phases:  # phases run concurrently if they are within the same step
   - namespaceRange:
       min: 1
-      max: 1
+      max: {{.nsCount}}
     replicasPerNamespace: {{$.oldReplicasAfterDeletion}}
     tuningSet: TargetDeleteQps  # (reference to tuning set from containing file)
     objectBundle:
@@ -28,7 +28,7 @@ steps:
       objectTemplatePath: "deployment.yaml"
   - namespaceRange:
       min: 1
-      max: 1
+      max: {{.nsCount}}
     replicasPerNamespace: {{$.newReplicas}} 
     tuningSet: TargetCreateQps # (reference to tuning set from containing file)
     objectBundle:

--- a/test/workloads/deployment-churn/config.yaml
+++ b/test/workloads/deployment-churn/config.yaml
@@ -12,7 +12,8 @@ name: deployment-churn
 {{$TARGET_POD_CHURN := DefaultParam .CL2_TARGET_POD_CHURN 10}}  # i.e. target pod churn, in mutations/sec, for cluster as a whole. (create+update+delete operations per second)
 {{$POD_START_TIMEOUT_MINS := DefaultParam .CL2_POD_START_TIMEOUT_MINS 5}}  # how long to wait, at end of a phase, for its pods to start up
 {{$CHURN_FRACTION := DefaultParam .CL2_CHURN_FRACTION 0.3}}
-{{$CLEANUP := DefaultParam .CL2_CLEANUP 1}}  
+{{$CLEANUP := DefaultParam .CL2_CLEANUP 1}}
+{{$NS_COUNT := DefaultParam .CL2_NS_COUNT 10}}  
 # Note on CLEANUP of pods and deployments that we create.
 # By default we do clean them up explicitly, because by default letting them just get deleted with the namespace is slow.
 # However, if delete-collection-workers has been set to a highish value (e.g. 250) in the API server params, then 
@@ -23,20 +24,21 @@ name: deployment-churn
 {{$desiredConcurrentPods := MultiplyInt .Nodes $ACTIVE_PODS_PER_NODE}}  #Total number of active pods for cluster
 {{$targetPodCreationsPerSecond := DivideInt $TARGET_POD_CHURN 6 }}  # The divisor here has been chosen by experimentation.  It allows for the create, the delete, and some patch operations that happen, and build the total pod churn (create, update, delete) up to approx the target
 {{$targetDeploymentCreationsPerSecond := DivideFloat $targetPodCreationsPerSecond $PODS_PER_DEPLOYMENT}}
-{{$desiredConcurrentDeployments := MaxInt 1 (DivideInt $desiredConcurrentPods $PODS_PER_DEPLOYMENT)}}  # must have at least 1 deplyoment
-{{$expectedConcurrentPods := MultiplyInt $desiredConcurrentDeployments $PODS_PER_DEPLOYMENT}}  # might be different from $desirnedConcurrentPods due to rounding etc
+{{$desiredConcurrentDeployments := MaxInt 1 (DivideFloat $desiredConcurrentPods $PODS_PER_DEPLOYMENT)}}  # must have at least 1 deplyoment
+{{$concurrentDeploymentsPerNS := MaxInt 1 (DivideFloat $desiredConcurrentDeployments $NS_COUNT)}}
 
 # Shorten the churn phase, by doing only part of it. We churn (i.e. delete and replace) $CHURN_FRACTION of the deployments
-{{$deploymentsToRecreate := MultiplyInt $desiredConcurrentDeployments $CHURN_FRACTION}}  # re-create this many
-{{$deploymentsToKeep := SubtractInt $desiredConcurrentDeployments $deploymentsToRecreate}} # keep this many from round 1, running throughpout round 2
+{{$deploymentsToRecreatePerNS := MultiplyInt $concurrentDeploymentsPerNS $CHURN_FRACTION}}  # re-create this many
+{{$deploymentsToKeepPerNS := SubtractInt $concurrentDeploymentsPerNS $deploymentsToRecreatePerNS}} # keep this many from round 1, running throughpout round 2
+{{$expectedConcurrentPods := MultiplyInt (MultiplyInt $concurrentDeploymentsPerNS $NS_COUNT) $PODS_PER_DEPLOYMENT}}  # might be different from $desirnedConcurrentPods due to rounding etc
 {{$expectedSecondsInStartupPhase := DivideInt $desiredConcurrentDeployments $targetDeploymentCreationsPerSecond}}  # expected duration of round 1
-{{$expectedSecondsInChurnPhase := DivideInt $deploymentsToRecreate $targetDeploymentCreationsPerSecond}}  # expected duration of round 2
+{{$expectedSecondsInChurnPhase := DivideInt (MultiplyInt $deploymentsToRecreatePerNS $NS_COUNT) $targetDeploymentCreationsPerSecond}}  # expected duration of round 2
 
 {{$podStartTimeout := print $POD_START_TIMEOUT_MINS "m"}}
 
 
 namespace:
-  number: 1  # testing everything in one namespace
+  number: {{$NS_COUNT}}
   deleteStaleNamespaces: true # delete any old ones from previous failed CL2 runs (We seem to need this, because stuff got pick up from other test namespaces, WaitForRunningPods. Don't know why! It shouldn't work like that.)
   deleteAutomanagedNamespaces: true # delete at end of test
   enableExistingNamespaces: false # only use the automanged ones that CL2 creates for us
@@ -53,7 +55,7 @@ steps:
 
 #### Log params ###
 # Can't find a log action, but the above name should function like a log, to let us see the computeed sleep seconds
-- name: Log - deployment creations {{$targetDeploymentCreationsPerSecond}}/s, , pods per deployment {{$PODS_PER_DEPLOYMENT}}, deployments to create/churn {{$desiredConcurrentDeployments}}/{{$deploymentsToRecreate}}, expected seconds in startup/churn phases {{$expectedSecondsInStartupPhase}}/{{$expectedSecondsInChurnPhase}}, pod start timeout {{$podStartTimeout}}
+- name: Log - deployment creations {{$targetDeploymentCreationsPerSecond}}/s, , pods per deployment {{$PODS_PER_DEPLOYMENT}}, deployments to create/churn perNS {{$concurrentDeploymentsPerNS}}/{{$deploymentsToRecreatePerNS}}, number of NSs {{$NS_COUNT}}, expected seconds in startup/churn phases {{$expectedSecondsInStartupPhase}}/{{$expectedSecondsInChurnPhase}}, pod start timeout {{$podStartTimeout}}
   measurements:
   - Identifier: Dummy
     Method: Sleep
@@ -77,20 +79,22 @@ steps:
       roundNumber: 1  # this is a setup round. It has nothing to delete
       desc: Prepare initial set of deployments
       oldReplicasAfterDeletion: 0
-      newReplicas: {{$desiredConcurrentDeployments}}
+      newReplicas: {{$concurrentDeploymentsPerNS}}
       podsPerDeployment: {{$PODS_PER_DEPLOYMENT}}
       totalPods: {{$expectedConcurrentPods}}
       timeout: {{$podStartTimeout}}
+      nsCount: {{$NS_COUNT}}
 - module:
     path: /churn-module.yaml
     params:
       roundNumber: 2  # this round does the real work
       desc: Do the churn test
-      oldReplicasAfterDeletion: {{$deploymentsToKeep}}  # delete all the old ones EXCEPT this many
-      newReplicas: {{$deploymentsToRecreate}}           # and create this many new ones
+      oldReplicasAfterDeletion: {{$deploymentsToKeepPerNS}}  # delete all the old ones EXCEPT this many
+      newReplicas: {{$deploymentsToRecreatePerNS}}           # and create this many new ones
       podsPerDeployment: {{$PODS_PER_DEPLOYMENT}}
       totalPods: {{$expectedConcurrentPods}}
       timeout: {{$podStartTimeout}}
+      nsCount: {{$NS_COUNT}}
 
 {{if ne $CLEANUP 0}}      
 - module:

--- a/test/workloads/deployment-churn/config.yaml
+++ b/test/workloads/deployment-churn/config.yaml
@@ -107,6 +107,7 @@ steps:
       podsPerDeployment: {{$PODS_PER_DEPLOYMENT}}
       totalPods: 0
       timeout: {{$podStartTimeout}}
+      nsCount: {{$NS_COUNT}}
 {{end}}
 
 ### Gather measurements

--- a/test/workloads/deployment-churn/config.yaml
+++ b/test/workloads/deployment-churn/config.yaml
@@ -10,10 +10,10 @@ name: deployment-churn
 {{$ACTIVE_PODS_PER_NODE := DefaultParam .CL2_PODS_PER_NODE 60}}
 {{$PODS_PER_DEPLOYMENT := DefaultParam .CL2_PODS_PER_DEPLOYMENT 100}}
 {{$TARGET_POD_CHURN := DefaultParam .CL2_TARGET_POD_CHURN 10}}  # i.e. target pod churn, in mutations/sec, for cluster as a whole. (create+update+delete operations per second)
-{{$POD_START_TIMEOUT_MINS := DefaultParam .CL2_POD_START_TIMEOUT_MINS 5}}  # how long to wait, at end of a phase, for its pods to start up
-{{$CHURN_FRACTION := DefaultParam .CL2_CHURN_FRACTION 0.3}}
-{{$CLEANUP := DefaultParam .CL2_CLEANUP 1}}
 {{$NS_COUNT := DefaultParam .CL2_NS_COUNT 10}}  
+{{$POD_START_TIMEOUT_MINS := DefaultParam .CL2_POD_START_TIMEOUT_MINS 5}}  # how long to wait, at end of a phase, for its pods to start up
+{{$CHURN_FRACTION := DefaultParam .CL2_CHURN_FRACTION 1.0}}  # Set below 1 for faster churn phase, IFF cleanup is set to 0
+{{$CLEANUP := DefaultParam .CL2_CLEANUP 1}}
 # Note on CLEANUP of pods and deployments that we create.
 # By default we do clean them up explicitly, because by default letting them just get deleted with the namespace is slow.
 # However, if delete-collection-workers has been set to a highish value (e.g. 250) in the API server params, then 
@@ -36,6 +36,10 @@ name: deployment-churn
 
 {{$podStartTimeout := print $POD_START_TIMEOUT_MINS "m"}}
 
+{{if and (ne $CLEANUP 0) (ne $CHURN_FRACTION 1.0)}}
+   # there is nothing actually called error:.  The next line will force a compliation error. Please read what it says, if you get the error
+   error: when using explicit cleanup, churn fraction must be 1.0 # otherwise the cleanup doesn't work
+{{end}}
 
 namespace:
   number: {{$NS_COUNT}}


### PR DESCRIPTION
The K8s thresholds doc says that SLOs are only guaranteed when pods per namespace <= 3000.  And testing indicates non-trivial differences in scheduling throughput between cases where everything is in one namespace, vs things are spread across multiple namespaces (with the latter being better).  This PR makes the deplyoment-churn test default to spreading the work over 10 namespaces.

It also adds validation to prevent unworkable combinations of `cleanup` and `churn fraction` settings.

And it updates sample command lines in the Readme.