### PR TITLE
Fix the calc of target rates

### DIFF
--- a/test/workloads/deployment-churn/config.yaml
+++ b/test/workloads/deployment-churn/config.yaml
@@ -22,7 +22,7 @@ name: deployment-churn
 
 # computed params
 {{$desiredConcurrentPods := MultiplyInt .Nodes $ACTIVE_PODS_PER_NODE}}  #Total number of active pods for cluster
-{{$targetPodCreationsPerSecond := DivideInt $TARGET_POD_CHURN 6 }}  # The divisor here has been chosen by experimentation.  It allows for the create, the delete, and some patch operations that happen, and build the total pod churn (create, update, delete) up to approx the target
+{{$targetPodCreationsPerSecond := DivideInt $TARGET_POD_CHURN 2 }}  # The divisor here is because we want half the churn to come from creates and half from deletes (there are no other pod _spec_ changes in this test, and it's only spec changes, not status changes, that count to the official definiton of churn)
 {{$targetDeploymentCreationsPerSecond := DivideFloat $targetPodCreationsPerSecond $PODS_PER_DEPLOYMENT}}
 {{$desiredConcurrentDeployments := MaxInt 1 (DivideFloat $desiredConcurrentPods $PODS_PER_DEPLOYMENT)}}  # must have at least 1 deplyoment
 {{$concurrentDeploymentsPerNS := MaxInt 1 (DivideFloat $desiredConcurrentDeployments $NS_COUNT)}}

--- a/test/workloads/naked-pod-churn/config.yaml
+++ b/test/workloads/naked-pod-churn/config.yaml
@@ -27,7 +27,7 @@ name: naked-pod-churn
 
 # computed params
 {{$desiredConcurrentPods := MultiplyInt .Nodes $ACTIVE_PODS_PER_NODE}}  #Total number of active pods for cluster
-{{$targetPodCreationsPerSecond := DivideInt $TARGET_POD_CHURN 6 }}  # The divisor here has been chosen by experimentation.  It allows for the create, the delete, and some patch operations that happen, and build the total pod churn (create, update, delete) up to approx the target
+{{$targetPodCreationsPerSecond := DivideInt $TARGET_POD_CHURN 2 }}  # The divisor here is because we want half the churn to come from creates and half from deletes (there are no other pod _spec_ changes in this test, and it's only spec changes, not status changes, that count to the official definiton of churn)
 {{$expectedSecondsInChurnPhase := DivideInt $desiredConcurrentPods $targetPodCreationsPerSecond}}
 {{$podStartTimeout := print $POD_START_TIMEOUT_MINS "m"}}
 


### PR DESCRIPTION
Previously, the calc was wrong.  Note that, when moving from
previous versions to this version you should divide your old
target churn parameter by 3. E.g. if you used to use 300, you
should use 100 now to get the same actual rate of churn.