### PR TITLE
Pre-delete some pods before each churn phase

### DIFF
--- a/test/workloads/deployment-churn/churn-module.yaml
+++ b/test/workloads/deployment-churn/churn-module.yaml
@@ -4,6 +4,9 @@
 # We have to do it in phases like this because deletion in CL2 is name-based, and so we need the things we are deleting right now
 # to have a different 'base name' from the things we are creating.
 
+# TODO: tidy usage of $.field vs .field (for accessing data passed in from config.yaml).  Since we have no loops here, and so
+# no new scopes defined, both should be equivalent - so it would be cleanest to standardize on one, probably the one without the $
+
 {{$previousRoundNum := SubtractInt $.roundNumber 1}}
 {{$fullRoundName := print $.desc " (rnd " $.roundNumber ")"}}
 # compute a slightly lower replicas per NS number, to represent the level we want to "pre-delete" to

--- a/test/workloads/deployment-churn/churn-module.yaml
+++ b/test/workloads/deployment-churn/churn-module.yaml
@@ -4,8 +4,13 @@
 # We have to do it in phases like this because deletion in CL2 is name-based, and so we need the things we are deleting right now
 # to have a different 'base name' from the things we are creating.
 
-{{$previousRoundNum := SubtractInt .roundNumber 1}}
+{{$previousRoundNum := SubtractInt $.roundNumber 1}}
 {{$fullRoundName := print $.desc " (rnd " $.roundNumber ")"}}
+# compute a slightly lower replicas per NS number, to represent the level we want to "pre-delete" to
+{{$preDelTargetOldReplicas := MaxInt (MultiplyInt $.newReplicas 0.9) $.oldReplicasAfterDeletion}} 
+# compute how many pods (not deployments) we want to see in total finally, and also after pre-deletion
+{{$finalPodCount        := MultiplyInt (AddInt $.newReplicas $.oldReplicasAfterDeletion) (MultiplyInt $.podsPerDeployment $.nsCount)}}
+{{$preDelTargetPodCount := MultiplyInt       $preDelTargetOldReplicas                    (MultiplyInt $.podsPerDeployment $.nsCount)}}
 
 steps:
 - name: begin CRUD timer 
@@ -16,6 +21,35 @@ steps:
       action: start
       label: CRUD for {{$fullRoundName}}
 
+{{if ne $.roundNumber 0.0}}
+# Before we do the real churn, pre-delete a few of the ones we don't want
+# If we don't do this, then we end up with a total number of pods that is greater than
+# what we really want.  Comprised of created new ones PLUS some delete ones that haven't quite gone away yet.
+# This causes the Cluster Autoscaler to have to scale out more, during the churn phase of the test - and we 
+# don't want that because it skews our result. So here, we pre-delete a few pods.
+# NOTE: when you're first learning how this test works, you can safely skip this section, and go 
+# straight to "Do the real churn test" below.
+- name: pre-deletion
+  phases:
+  - namespaceRange:
+      min: 1
+      max: {{.nsCount}}
+    replicasPerNamespace: {{$preDelTargetOldReplicas}}  # set target of having slightly fewer pods than normal, from the previous round
+    tuningSet: TargetDeleteQps  # (reference to tuning set from containing file)
+    objectBundle:
+    - basename: deployment-rnd-{{$previousRoundNum}}-instance  # delete the previous set
+      objectTemplatePath: "deployment.yaml"
+- name: wait for pre-deletion  # wait to make sure the pre-deletion really has worked
+  measurements:
+  - Identifier: WaitForRunningPods 
+    Method: WaitForRunningPods
+    Params:
+      desiredPodCount: {{$preDelTargetPodCount}} 
+      labelSelector: test-round in (r{{$previousRoundNum}})  
+      timeout: {{$.timeout}}  
+{{end}}          
+
+# Do the real churn test
 - name: {{$fullRoundName}}
   phases:  # phases run concurrently if they are within the same step
   - namespaceRange:
@@ -25,7 +59,7 @@ steps:
     tuningSet: TargetDeleteQps  # (reference to tuning set from containing file)
     objectBundle:
     - basename: deployment-rnd-{{$previousRoundNum}}-instance  # delete the previous set
-      objectTemplatePath: "deployment.yaml"
+      objectTemplatePath: "deployment.yaml"  
   - namespaceRange:
       min: 1
       max: {{.nsCount}}
@@ -58,7 +92,7 @@ steps:
   - Identifier: WaitForRunningPods  # unlike WaitForControlledPods, this does not seem to require separate setup and gather phases
     Method: WaitForRunningPods
     Params:
-      desiredPodCount: {{$.totalPods}} 
+      desiredPodCount: {{$finalPodCount}} 
       labelSelector: test-round in (r0, r{{$.roundNumber}})  # since we may carry some over from round 0
       timeout: {{$.timeout}}
 

--- a/test/workloads/deployment-churn/config.yaml
+++ b/test/workloads/deployment-churn/config.yaml
@@ -32,7 +32,7 @@ name: deployment-churn
 # Shorten the churn phase, by doing only part of it. We churn (i.e. delete and replace) $CHURN_FRACTION of the deployments
 {{$deploymentsToRecreatePerNS := MultiplyInt $concurrentDeploymentsPerNS $CHURN_FRACTION}}  # re-create this many
 {{$deploymentsToKeepPerNS := SubtractInt $concurrentDeploymentsPerNS $deploymentsToRecreatePerNS}} # keep this many from round 1, running throughpout round 2
-{{$expectedConcurrentPods := MultiplyInt (MultiplyInt $concurrentDeploymentsPerNS $NS_COUNT) $PODS_PER_DEPLOYMENT}}  # might be different from $desirnedConcurrentPods due to rounding etc
+
 {{$expectedSecondsInStartupPhase := DivideInt $desiredConcurrentDeployments $targetDeploymentCreationsPerSecond}}  # expected duration of round 1
 {{$expectedSecondsInChurnPhase := DivideInt (MultiplyInt $deploymentsToRecreatePerNS $NS_COUNT) $targetDeploymentCreationsPerSecond}}  # expected duration of round 2
 
@@ -92,7 +92,6 @@ steps:
       oldReplicasAfterDeletion: 0
       newReplicas: {{$concurrentDeploymentsPerNS}}
       podsPerDeployment: {{$PODS_PER_DEPLOYMENT}}
-      totalPods: {{$expectedConcurrentPods}}
       timeout: {{$podStartTimeout}}
       nsCount: {{$NS_COUNT}}
 
@@ -106,7 +105,6 @@ steps:
       oldReplicasAfterDeletion: {{$deploymentsToKeepPerNS}}  # delete all the old ones EXCEPT this many
       newReplicas: {{$deploymentsToRecreatePerNS}}           # and create this many new ones
       podsPerDeployment: {{$PODS_PER_DEPLOYMENT}}
-      totalPods: {{$expectedConcurrentPods}}
       timeout: {{$podStartTimeout}}
       nsCount: {{$NS_COUNT}}
 {{end}}      


### PR DESCRIPTION
This is to make it more likely that our _actual_ total pod count never exceeds our _desired_ total pod count. (Since when it's exceeded, that can produce delays in scheduling things if our nodes are very "full" of pods - i.e. close to max capacity.  As they always are if running with Cluster Autoscaler).