### PR TITLE
ci: enable tests on main branch

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -12,7 +12,7 @@ on:
         default: 'main'
 jobs:
   ci-e2e:
-    if: contains(github.event.pull_request.labels.*.name, 'safe to test') || github.ref == 'refs/heads/main'
+    if: contains(github.event.pull_request.labels.*.name, 'safe to test') || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR updates the GitHub Action to allow tests to actually run on demand from a branch