### PR TITLE
Statefulset pod churn controller

### DIFF
--- a/test/workloads/deployment-churn/churn-module.yaml
+++ b/test/workloads/deployment-churn/churn-module.yaml
@@ -40,8 +40,8 @@ steps:
     replicasPerNamespace: {{$preDelTargetOldReplicas}}  # set target of having slightly fewer pods than normal, from the previous round
     tuningSet: TargetDeleteQps  # (reference to tuning set from containing file)
     objectBundle:
-    - basename: deployment-rnd-{{$previousRoundNum}}-instance  # delete the previous set
-      objectTemplatePath: "deployment.yaml"
+    - basename: {{$.podController}}-rnd-{{$previousRoundNum}}-instance  # delete the previous set
+      objectTemplatePath: {{$.podController}}.yaml
 - name: wait for pre-deletion  # wait to make sure the pre-deletion really has worked
   measurements:
   - Identifier: WaitForRunningPods 
@@ -61,19 +61,21 @@ steps:
     replicasPerNamespace: {{$.oldReplicasAfterDeletion}}
     tuningSet: TargetDeleteQps  # (reference to tuning set from containing file)
     objectBundle:
-    - basename: deployment-rnd-{{$previousRoundNum}}-instance  # delete the previous set
-      objectTemplatePath: "deployment.yaml"  
+    - basename: {{$.podController}}-rnd-{{$previousRoundNum}}-instance  # delete the previous set
+      objectTemplatePath: {{$.podController}}.yaml
   - namespaceRange:
       min: 1
       max: {{.nsCount}}
     replicasPerNamespace: {{$.newReplicas}} 
     tuningSet: TargetCreateQps # (reference to tuning set from containing file)
     objectBundle:
-    - basename: deployment-rnd-{{$.roundNumber}}-instance  # create the new set
-      objectTemplatePath: "deployment.yaml"
+    - basename: {{$.podController}}-rnd-{{$.roundNumber}}-instance  # create the new set
+      objectTemplatePath: {{$.podController}}.yaml
       templateFillMap:
         testRound: r{{$.roundNumber}}
         replicas: {{$.podsPerDeployment}}
+        pvcStorageQuantity: {{$.pvcStorageQuantity}}
+        pvcStorageClass:  {{$.pvcStorageClass}}
 
 - name: end CRUD timer
   measurements:

--- a/test/workloads/deployment-churn/config.yaml
+++ b/test/workloads/deployment-churn/config.yaml
@@ -16,11 +16,16 @@ name: deployment-churn
 {{$CHURN_FRACTION := DefaultParam .CL2_CHURN_FRACTION 1.0}}  # Set below 1 for faster churn phase, IFF cleanup is set to 0
 {{$REPEATS := DefaultParam .CL2_REPEATS 1}}  # How many times to repeat the churn phase.  Set to non-zero value for longer-running tests
 {{$CLEANUP := DefaultParam .CL2_CLEANUP 1}}
+{{$POD_CONTROLLER := DefaultParam .CL2_POD_CONTROLLER "deployment"}}
 # Note on CLEANUP of pods and deployments that we create.
 # By default we do clean them up explicitly, because by default letting them just get deleted with the namespace is slow.
 # However, if delete-collection-workers has been set to a highish value (e.g. 250) in the API server params, then 
 # there is no need for us to delete them explicitly. They'l be deleted quickly when this test deletes its namespace.
 # So, if you have set that parameter in your API server, then set the CL2_CLEANUP parameter to 0
+
+# POD_CONTROLLER == statefulSet params
+{{$PVC_STORAGE_CLASS := DefaultParam .CL2_PVC_STORAGE_CLASS "azurefile-csi"}} # azurefile-csi, azurefile-csi-premium, managed-csi, managed-csi-premium
+{{$PVC_STORAGE_QUANTITY := DefaultParam .CL2_PVC_STORAGE_QUANTITY "8Gi"}}    #must be > 100Gi for '-premium' storage classes
 
 # computed params
 {{$desiredConcurrentPods := MultiplyInt $NODE_COUNT $ACTIVE_PODS_PER_NODE}}  #Total number of active pods for cluster
@@ -38,6 +43,7 @@ name: deployment-churn
 
 {{$podStartTimeout := print $POD_START_TIMEOUT_MINS "m"}}
 
+# validation
 {{if and (ne $CLEANUP 0) (ne $CHURN_FRACTION 1.0)}}
    # there is nothing actually called error:.  The next line will force a compliation error. Please read what it says, if you get the error
    error: when using explicit cleanup, churn fraction must be 1.0 # otherwise the cleanup doesn't work
@@ -47,6 +53,11 @@ name: deployment-churn
    # there is nothing actually called error:.  The next line will force a compliation error. Please read what it says, if you get the error
    error: when using more than 1 repeat, churn fraction must be 1.0 # otherwise our churn code doesn't work properly, and there's no point anywany, because the whole point of $REPEATS is longer test, and the whole point of Churn Fraction < 1 is shorter tests
 {{end}}
+
+{{if and (ne $POD_CONTROLLER "deployment") (ne $POD_CONTROLLER "statefulset")}}
+   error: unrecognized value for POD_CONTROLLER $POD_CONTROLLER, supported values are "deployment" and "statefulset"
+{{end}}
+
 
 namespace:
   number: {{$NS_COUNT}}
@@ -66,7 +77,7 @@ steps:
 
 #### Log params ###
 # Can't find a log action, but the above name should function like a log, to let us see the computeed sleep seconds
-- name: Log - deployment creations {{$targetDeploymentCreationsPerSecond}}/s, pods per deployment {{$PODS_PER_DEPLOYMENT}}, deployments to create/churn per namespace {{$concurrentDeploymentsPerNS}}/{{$deploymentsToRecreatePerNS}}, current/target nodes {{$.Nodes}}/{{$NODE_COUNT}}, number of namespaces {{$NS_COUNT}}, expected seconds in startup/one churn phase {{$expectedSecondsInStartupPhase}}/{{$expectedSecondsInChurnPhase}}, num churn phases {{$REPEATS}}, pod start timeout {{$podStartTimeout}}
+- name: Log - {{$POD_CONTROLLER}} creations {{$targetDeploymentCreationsPerSecond}}/s, pods per deployment {{$PODS_PER_DEPLOYMENT}}, deployments to create/churn per namespace {{$concurrentDeploymentsPerNS}}/{{$deploymentsToRecreatePerNS}}, current/target nodes {{$.Nodes}}/{{$NODE_COUNT}}, number of namespaces {{$NS_COUNT}}, expected seconds in startup/one churn phase {{$expectedSecondsInStartupPhase}}/{{$expectedSecondsInChurnPhase}}, num churn phases {{$REPEATS}}, pod start timeout {{$podStartTimeout}}
   measurements:
   - Identifier: Dummy
     Method: Sleep
@@ -94,6 +105,9 @@ steps:
       podsPerDeployment: {{$PODS_PER_DEPLOYMENT}}
       timeout: {{$podStartTimeout}}
       nsCount: {{$NS_COUNT}}
+      podController: {{$POD_CONTROLLER}}
+      pvcStorageQuantity: {{$PVC_STORAGE_QUANTITY}}
+      pvcStorageClass:  {{$PVC_STORAGE_CLASS}}
 
 ### One or more rounds of churn
 {{range $i := Loop $REPEATS}}
@@ -107,6 +121,9 @@ steps:
       podsPerDeployment: {{$PODS_PER_DEPLOYMENT}}
       timeout: {{$podStartTimeout}}
       nsCount: {{$NS_COUNT}}
+      podController: {{$POD_CONTROLLER}}
+      pvcStorageQuantity: {{$PVC_STORAGE_QUANTITY}}
+      pvcStorageClass:  {{$PVC_STORAGE_CLASS}}
 {{end}}      
 
 ### cleanup
@@ -122,6 +139,9 @@ steps:
       totalPods: 0
       timeout: {{$podStartTimeout}}
       nsCount: {{$NS_COUNT}}
+      podController: {{$POD_CONTROLLER}}
+      pvcStorageQuantity: {{$PVC_STORAGE_QUANTITY}}
+      pvcStorageClass:  {{$PVC_STORAGE_CLASS}}
 {{end}}
 
 ### Gather measurements

--- a/test/workloads/deployment-churn/deployment.yaml
+++ b/test/workloads/deployment-churn/deployment.yaml
@@ -18,4 +18,4 @@ spec:
     spec:    
       containers:
       - name: load-test
-        image: k8s.gcr.io/pause:3.1
+        image: mcr.microsoft.com/oss/kubernetes/pause:3.4.1 #locally present image, prevents need to pull

--- a/test/workloads/deployment-churn/statefulset.yaml
+++ b/test/workloads/deployment-churn/statefulset.yaml
@@ -9,6 +9,7 @@ spec:
       test-round: {{$.testRound}} 
   serviceName: "unused"
   replicas: {{$.replicas}}
+  podManagementPolicy: Parallel
   template:
     metadata:
       labels:

--- a/test/workloads/deployment-churn/statefulset.yaml
+++ b/test/workloads/deployment-churn/statefulset.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{.Name}}
+spec:
+  selector:
+    matchLabels:
+      test-round: {{$.testRound}} 
+  serviceName: "unused"
+  replicas: {{$.replicas}}
+  template:
+    metadata:
+      labels:
+        app: {{.Name}}
+        test-round: {{$.testRound}}
+    spec:
+       containers:
+        - name: load-test
+          image: mcr.microsoft.com/oss/kubernetes/pause:3.4.1 #locally present image, prevents need to pull
+          volumeMounts:
+          - mountPath: /data
+            name: {{.Name}}-data
+  volumeClaimTemplates:
+  - metadata:
+      name: {{.Name}}-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: {{$.pvcStorageClass}}
+      resources:
+        requests:
+         storage: {{$.pvcStorageQuantity}} # when supporting premium storage classes, this will need to change to >= 100Gi as that is minimum supported, see note: https://docs.microsoft.com/en-us/azure/aks/azure-files-csi#dynamically-create-azure-files-pvs-by-using-the-built-in-storage-classes


### PR DESCRIPTION
Runs successfully for storageClass == azurefile-csi, testing others.

new params:
CL2_POD_CONTROLLER=(deployment, statefulset) 

New params for statefulset only:
CL2_PVC_STORAGE_CLASS=(azurefile-csi*, azurefile-csi-premium, managed-csi, managed-csi-premium) 
CL2_PVC_STORAGE_QUANTITY=8Gi*
(* default value)


