### PR TITLE
use AKS MCR pause image

### DIFF
--- a/test/workloads/deployment-churn/deployment.yaml
+++ b/test/workloads/deployment-churn/deployment.yaml
@@ -18,4 +18,4 @@ spec:
     spec:    
       containers:
       - name: load-test
-        image: k8s.gcr.io/pause:3.1
+        image: mcr.microsoft.com/oss/kubernetes/pause:3.5

--- a/test/workloads/naked-pod-churn/naked-pod.yaml
+++ b/test/workloads/naked-pod-churn/naked-pod.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:    
   containers:
   - name: load-test
-    image: k8s.gcr.io/pause:3.1
+    image: mcr.microsoft.com/oss/kubernetes/pause:3.5


### PR DESCRIPTION
This PR updates the pause image references in test specs so that we use the image already present on AKS nodes.