### PR TITLE
wait longer for clusters

### DIFF
--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -82,9 +82,9 @@ variables:
 
 intervals:
   default/wait-controllers: ["3m", "10s"]
-  default/wait-cluster: ["20m", "10s"]
-  default/wait-control-plane: ["20m", "10s"]
-  default/wait-worker-nodes: ["20m", "10s"]
+  default/wait-cluster: ["60m", "10s"]
+  default/wait-control-plane: ["60m", "10s"]
+  default/wait-worker-nodes: ["60m", "10s"]
   default/wait-delete-cluster: ["30m", "10s"]
   default/wait-machine-upgrade: ["60m", "10s"]
   default/wait-machine-remediation: ["30m", "10s"]


### PR DESCRIPTION
This PR adds more wait tolerance for test clusters in response to recent test run timeouts.