### PR TITLE
use 5 AKS node pools for tests

### DIFF
--- a/overlays/clusters/aks/kustomization.yaml
+++ b/overlays/clusters/aks/kustomization.yaml
@@ -5,6 +5,9 @@ resources:
   - ../../../bases/azure_managed_control_plane.yaml
   - nodepool0
   - nodepool1
+  - nodepool2
+  - nodepool3
+  - nodepool4
 patchesStrategicMerge:
   - infra_ref_patch.yaml
   - ../../identities/azure_managed_control_plane_patch.yaml

--- a/overlays/clusters/aks/nodepool2/kustomization.yaml
+++ b/overlays/clusters/aks/nodepool2/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - ../../../nodepools/aks
+nameSuffix: "2"

--- a/overlays/clusters/aks/nodepool3/kustomization.yaml
+++ b/overlays/clusters/aks/nodepool3/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - ../../../nodepools/aks
+nameSuffix: "3"

--- a/overlays/clusters/aks/nodepool4/kustomization.yaml
+++ b/overlays/clusters/aks/nodepool4/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - ../../../nodepools/aks
+nameSuffix: "4"

--- a/templates/flavors/cluster-template-aks.yaml
+++ b/templates/flavors/cluster-template-aks.yaml
@@ -107,3 +107,87 @@ spec:
         kind: AzureManagedMachinePool
         name: nodepool1
       version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+kind: AzureManagedMachinePool
+metadata:
+  name: nodepool2
+spec:
+  mode: System
+  osDiskSizeGB: 512
+  sku: ${AZURE_NODE_MACHINE_TYPE}
+---
+apiVersion: cluster.x-k8s.io/v1alpha4
+kind: MachinePool
+metadata:
+  name: nodepool2
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
+  template:
+    metadata: {}
+    spec:
+      bootstrap:
+        dataSecretName: ""
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+        kind: AzureManagedMachinePool
+        name: nodepool2
+      version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+kind: AzureManagedMachinePool
+metadata:
+  name: nodepool3
+spec:
+  mode: System
+  osDiskSizeGB: 512
+  sku: ${AZURE_NODE_MACHINE_TYPE}
+---
+apiVersion: cluster.x-k8s.io/v1alpha4
+kind: MachinePool
+metadata:
+  name: nodepool3
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
+  template:
+    metadata: {}
+    spec:
+      bootstrap:
+        dataSecretName: ""
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+        kind: AzureManagedMachinePool
+        name: nodepool3
+      version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+kind: AzureManagedMachinePool
+metadata:
+  name: nodepool4
+spec:
+  mode: System
+  osDiskSizeGB: 512
+  sku: ${AZURE_NODE_MACHINE_TYPE}
+---
+apiVersion: cluster.x-k8s.io/v1alpha4
+kind: MachinePool
+metadata:
+  name: nodepool4
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
+  template:
+    metadata: {}
+    spec:
+      bootstrap:
+        dataSecretName: ""
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+        kind: AzureManagedMachinePool
+        name: nodepool4
+      version: ${KUBERNETES_VERSION}


### PR DESCRIPTION
This PR adds more node pools to the AKS knarly CI cluster to prepare for 5k node clusters.