### PR TITLE
copy capz cluster-api metadata.yaml

### DIFF
--- a/test/e2e/data/shared/metadata.yaml
+++ b/test/e2e/data/shared/metadata.yaml
@@ -13,3 +13,6 @@ releaseSeries:
   - major: 0
     minor: 3
     contract: v1alpha3
+  - major: 0
+    minor: 2
+    contract: v1alpha2


### PR DESCRIPTION
This PR restores the v1alpha2 cluster-api contract because that's what capz @ release-1.3 is declaring:

- https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/release-1.3/test/e2e/data/shared/v1beta1/metadata.yaml