### PR TITLE
capi v1.1.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	k8s.io/apimachinery v0.23.4
 	k8s.io/client-go v0.23.4
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed
-	sigs.k8s.io/cluster-api v1.1.1
+	sigs.k8s.io/cluster-api v1.1.2
 	sigs.k8s.io/cluster-api-provider-azure v1.3.1
 	sigs.k8s.io/cluster-api/test v1.1.2
 	sigs.k8s.io/controller-runtime v0.11.1

--- a/test/e2e/data/shared/metadata.yaml
+++ b/test/e2e/data/shared/metadata.yaml
@@ -1,3 +1,8 @@
+# maps release series of major.minor to cluster-api contract version
+# the contract version may change between minor or major versions, but *not*
+# between patch versions.
+#
+# update this file only when a new major or minor version is released
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
@@ -13,6 +18,3 @@ releaseSeries:
   - major: 0
     minor: 3
     contract: v1alpha3
-  - major: 0
-    minor: 2
-    contract: v1alpha2

--- a/test/e2e/data/shared/metadata.yaml
+++ b/test/e2e/data/shared/metadata.yaml
@@ -1,8 +1,3 @@
-# maps release series of major.minor to cluster-api contract version
-# the contract version may change between minor or major versions, but *not*
-# between patch versions.
-#
-# update this file only when a new major or minor version is released
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
@@ -18,3 +13,6 @@ releaseSeries:
   - major: 0
     minor: 3
     contract: v1alpha3
+  - major: 0
+    minor: 2
+    contract: v1alpha2


### PR DESCRIPTION
This PR updates capi to v1.1.2 and uses its v1beta1 metadata.yaml. See:

- https://github.com/kubernetes-sigs/cluster-api/blob/v1.1.2/test/e2e/data/shared/v1beta1/metadata.yaml

