### PR TITLE
copy v1beta1_provider metadata.yaml from capz

### DIFF
--- a/test/e2e/data/shared/infra_metadata.yaml
+++ b/test/e2e/data/shared/infra_metadata.yaml
@@ -20,9 +20,3 @@ releaseSeries:
   - major: 1
     minor: 1
     contract: v1beta1
-  - major: 1
-    minor: 2
-    contract: v1beta1
-  - major: 1
-    minor: 3
-    contract: v1beta1


### PR DESCRIPTION
This PR updates the provider metadata.yaml from here:

https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/v1.3.1/test/e2e/data/shared/v1beta1_provider/metadata.yaml