### PR TITLE
restore infra_metadata.yaml from capz root

### DIFF
--- a/test/e2e/data/shared/infra_metadata.yaml
+++ b/test/e2e/data/shared/infra_metadata.yaml
@@ -20,3 +20,9 @@ releaseSeries:
   - major: 1
     minor: 1
     contract: v1beta1
+  - major: 1
+    minor: 2
+    contract: v1beta1
+  - major: 1
+    minor: 3
+    contract: v1beta1


### PR DESCRIPTION
This PR restores the `infra_metadata.yaml` from here:

- https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/v1.3.1/metadata.yaml